### PR TITLE
Fix Thunderbird 58 compatibility

### DIFF
--- a/components/transformer.js
+++ b/components/transformer.js
@@ -15,8 +15,10 @@ const CLASS_ID = Components.ID("{4A373444-8A2A-4641-ADD5-897A88D05185}"),
 let Transformation = (function () {
 
 // Some shortcuts for brevity.
-const fcc = String.fromCharCode,
-	  up = String.toUpperCase;
+const fcc = String.fromCharCode;
+const up = function (str) {
+	return str.toUpperCase();
+};
 
 function nan(w) {
 	return isNaN(w) || w === "e";

--- a/content/addonsOverlay.js
+++ b/content/addonsOverlay.js
@@ -57,9 +57,15 @@ function ExtensionMonitor() {
 	 * enabled.
 	 */
 	this.registerPrefs = function() {
-		avimPrefs.QueryInterface(Ci.nsIPrefBranch2);
-		mudimPrefs.QueryInterface(Ci.nsIPrefBranch2);
-		mudimPrefs2.QueryInterface(Ci.nsIPrefBranch2);
+		if ("nsIPrefBranch2" in Ci) {
+			avimPrefs.QueryInterface(Ci.nsIPrefBranch2);
+			mudimPrefs.QueryInterface(Ci.nsIPrefBranch2);
+			mudimPrefs2.QueryInterface(Ci.nsIPrefBranch2);
+		} else {
+			avimPrefs.QueryInterface(Ci.nsIPrefBranch);
+			mudimPrefs.QueryInterface(Ci.nsIPrefBranch);
+			mudimPrefs2.QueryInterface(Ci.nsIPrefBranch);
+		}
 		avimPrefs.addObserver(avimEnabledId, this, false);
 		mudimPrefs.addObserver(mudimMethodId, this, false);
 		mudimPrefs2.addObserver(mudimMethodId, this, false);

--- a/content/addonsOverlay.xul
+++ b/content/addonsOverlay.xul
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <overlay id="avim-addons-overlay" xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">
-	<script type="application/x-javascript;version=1.7" src="chrome://avim/content/addonsOverlay.js" />
+	<script type="application/javascript" language="JavaScript1.7" src="chrome://avim/content/addonsOverlay.js" />
 	
 	<stringbundleset>
 		<stringbundle id="avim-bundle" src="chrome://avim/locale/options.properties" />

--- a/content/avim.js
+++ b/content/avim.js
@@ -339,7 +339,8 @@ function AVIM()	{
 	this.registerPrefs = function() {
 		if (this.prefsRegistered) return;
 		this.prefsRegistered = true;
-		prefs.QueryInterface(Ci.nsIPrefBranch2);
+		if ("nsIPrefBranch2" in Ci) prefs.QueryInterface(Ci.nsIPrefBranch2);
+		else prefs.QueryInterface(Ci.nsIPrefBranch);
 		prefs.addObserver("", this, false);
 		this.getPrefs();
 	};
@@ -431,8 +432,12 @@ function AVIM()	{
 		// Custom string preferences
 		if (!changedPref || changedPref === "ignoredFieldIds") {
 			let ids = AVIMConfig.exclude.join(" ").toLowerCase();
-			prefs.setComplexValue("ignoredFieldIds", Ci.nsISupportsString,
-								  makeSupportsString(ids));
+			if ("setStringPref" in prefs) {
+				prefs.setStringPref("ignoredFieldIds", ids);
+			} else {
+				prefs.setComplexValue("ignoredFieldIds", Ci.nsISupportsString,
+									  makeSupportsString(ids));
+			}
 		}
 	};
 	
@@ -492,8 +497,13 @@ function AVIM()	{
 				AVIMConfig.passwords = prefs.getBoolPref("passwords");
 				if (specificPref) break;
 			case "ignoredFieldIds":
-				let ids = prefs.getComplexValue("ignoredFieldIds",
+				let ids;
+				if ("getStringPref" in prefs) {
+					ids = prefs.getStringPref("ignoredFieldIds");
+				} else {
+					ids = prefs.getComplexValue("ignoredFieldIds",
 												Ci.nsISupportsString).data;
+				}
 				AVIMConfig.exclude = ids.toLowerCase().split(/\s+/);
 				if (specificPref) break;
 			

--- a/content/avim.xul
+++ b/content/avim.xul
@@ -3,8 +3,8 @@
 <!DOCTYPE overlay SYSTEM "chrome://avim/locale/avim.dtd">
 
 <overlay id="avim-overlay" xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">
-	<script type="application/x-javascript;version=1.7" src="chrome://avim/content/avim.js" />
-	<script type="application/x-javascript;version=1.7" src="chrome://avim/content/frame.js" />
+	<script type="application/javascript" language="JavaScript1.7" src="chrome://avim/content/avim.js" />
+	<script type="application/javascript" language="JavaScript1.7" src="chrome://avim/content/frame.js" />
 	
 	<commandset>
 		<command id="avim-enabled-cmd" oncommand="avim.toggle(); event.stopPropagation();" />

--- a/content/optionsOverlay.xul
+++ b/content/optionsOverlay.xul
@@ -7,8 +7,8 @@
 <?xul-overlay href="chrome://global/content/editMenuOverlay.xul"?>
 
 <overlay id="avim-options-overlay" xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">
-	<script type="application/x-javascript;version=1.7" src="chrome://mozapps/content/extensions/extensions.js" />
-	<script type="application/x-javascript;version=1.7" src="chrome://avim/content/options.js" />
+	<script type="application/javascript" language="JavaScript1.7" src="chrome://mozapps/content/extensions/extensions.js" />
+	<script type="application/javascript" language="JavaScript1.7" src="chrome://avim/content/options.js" />
 	
 	<broadcasterset id="mainBroadcasterSet">
 		<broadcaster id="disabled-bc" />

--- a/content/test/tester.xul
+++ b/content/test/tester.xul
@@ -9,7 +9,7 @@
 <!-- <!DOCTYPE window SYSTEM "chrome://avim/locale/test/tester.dtd"> -->
 
 <window id="avim-tester" xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul" xmlns:html="http://www.w3.org/1999/xhtml" class="windowDialog" windowtype="avim:tester" title="AVIM Test Suite" width="600" height="400" screenX="20" screenY="20" persist="screenX screenY width height">
-	<script type="application/x-javascript;version=1.7" src="chrome://avim/content/test/tester.js" />
+	<script type="application/javascript" language="JavaScript1.7" src="chrome://avim/content/test/tester.js" />
 	
 	<stringbundleset id="stringbundleset" />
 	

--- a/tests/transformer.html
+++ b/tests/transformer.html
@@ -5,14 +5,14 @@
     <title>AVIMTransformerService</title>
     
     <meta charset="UTF-8" />
-    <script type="text/javascript;version=1.7">
+    <script type="text/javascript">
         "use strict";
         
         window.load = function (url) {
             document.write();
             
             let script = document.createElement("script");
-            script.setAttribute("type", "text/javascript;version=1.7");
+            script.setAttribute("type", "text/javascript");
             script.setAttribute("src", url);
             document.head.appendChild(script);
         };
@@ -37,9 +37,9 @@
             ID: function () {},
         };
     </script>
-    <script type="text/javascript;version=1.7" src="assert.js"></script>
-    <script type="text/javascript;version=1.7" src="../components/transformer.js"></script>
-    <script type="text/javascript;version=1.7">
+    <script type="text/javascript" src="assert.js"></script>
+    <script type="text/javascript" src="../components/transformer.js"></script>
+    <script type="text/javascript">
         let xformer = new AVIMTransformerService();
         
         function applyKey(word, keyChar) {


### PR DESCRIPTION
Various fixes to restore compatibility with Thunderbird 58, guided by [this helpful document](https://wiki.mozilla.org/Thunderbird/Add-ons_Guide_57):

* [x] Remove version from JavaScript MIME type
* [x] Migrate from `nsIPrefBranch2` to `nsIPrefBranch` and away from `nsISupportsString` (fixes #187)
* [x] Fix a warning about `String.toUpperCase()` being deprecated in favor of `String.prototype.toUpperCase()`

#191 doesn’t affect Thunderbird 58, so it’s out of scope for this PR.