### PR TITLE
Fall back to KeyboardEvent.key if keyCode is absent

### DIFF
--- a/components/transformer.js
+++ b/components/transformer.js
@@ -165,10 +165,16 @@ function _Transformation(startValue, context) {
 		ckSpell: context.ckSpell,
 		informal: context.informal,
 		oldAccent: context.oldAccent,
+		key: context.key,
 		keyCode: context.keyCode,
 		which: context.which,
 		shiftKey: context.shiftKey,
 	};
+	
+	if ("nsIDOMKeyEvent" in Ci && "DOM_VK_BACK_SPACE" in Ci.nsIDOMKeyEvent &&
+		context.keyCode === Ci.nsIDOMKeyEvent.DOM_VK_BACK_SPACE) {
+		this.context.key = "Backspace";
+	}
 /* jshint +W040 */
 }
 
@@ -370,8 +376,7 @@ _Transformation.prototype = {
 		if (!w) return;
 		//dump(">>> start() -- w: <" + w + ">\n");								// debug
 		let key = "";
-		const backspace = Ci.nsIDOMKeyEvent.DOM_VK_BACK_SPACE;
-		if (!this.context.keyCode || this.context.keyCode !== backspace ||
+		if (this.context.keyCode === 0 || this.context.key !== "Backspace" ||
 			!this.context.shiftKey) {
 			key = fcc(this.context.which);
 		}

--- a/content/avim.js
+++ b/content/avim.js
@@ -680,6 +680,7 @@ function AVIM()	{
 			ckSpell: AVIMConfig.ckSpell,
 			informal: AVIMConfig.informal,
 			oldAccent: AVIMConfig.oldAccent,
+			key: evt.key,
 			keyCode: evt.keyCode,
 			which: evt.which,
 			shiftKey: evt.shiftKey,

--- a/content/frame.js
+++ b/content/frame.js
@@ -361,6 +361,7 @@ function applyKey(word, evt) {
 	let data = {
 		prefix: word,
 		evt: {
+			key: evt.key,
 			keyCode: evt.keyCode,
 			which: evt.which,
 			shiftKey: evt.shiftKey,
@@ -403,12 +404,15 @@ function splice(outer, evt) {
 	if (!node || !sel.anchorOffset || !node.data) return result;
 	
 	let word = lastWordInString(node.substringData(0, sel.anchorOffset));
-	let key = String.fromCharCode(evt.which);
+	let which = evt.which;
 	result = word && applyKey(word, evt);
 	//dump("AVIM.splice -- editor: " + editor +
 	//	 "; old word: " + word + "; key: " + key +
 	//	 "; new word: " + (result && result.value) + "\n");						// debug
-	if (!result || (word && result.value === word + key)) return {};
+	if (!result) return {};
+	if (word && which && result.value === word + String.fromCharCode(which)) {
+		return {};
+	}
 	
 	// Carry out the transaction.
 	// (#123) convertCustomChars() can increase the word length.
@@ -543,8 +547,7 @@ function deleteDiacritic() {
 	let node = getSelectedNode(editor);
 	if (node instanceof Ci.nsIDOMText) {
 		splice(outer, {
-			keyCode: Ci.nsIDOMKeyEvent.DOM_VK_BACK_SPACE,
-			which: Ci.nsIDOMKeyEvent.DOM_VK_BACK_SPACE,
+			key: "Backspace",
 			shiftKey: true,
 		});
 	}


### PR DESCRIPTION
Fixed the inability to add diacritics in Thunderbird 60 or above.

Recent versions of Gecko have removed `Components.interfaces.nsIDOMKeyEvent`, which the transformer previously used to detect a `KeyboardEvent.keyCode` of `DOM_VK_BACK_SPACE`. When `nsIDOMKeyEvent` is absent, the transformer now falls back to `KeyboardEvent.key` to detect a backspace or shift-backspace.

Fixes #194.